### PR TITLE
Adds --output param.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import * as exec from '@actions/exec'
 export async function build(): Promise<void> {
   const path = core.getInput('path', {required: true})
   try {
-    await exec.exec(`npx @11ty/eleventy ${path}`)
+    await exec.exec(`npx @11ty/eleventy --output=${path}`)
   } catch (error) {
     core.setFailed(error.message)
   }


### PR DESCRIPTION
Somewhere between December and March, this GitHub Action stopped working for me. The error that started appearing in the deployment logs was:

```
`EleventyCommandCheckError` was thrown:
[11ty]     EleventyCommandCheckError: We don’t know what '/home/runner/work/repo/site' is. Use --help to see the list of supported commands.
```

Looking at this message, I determined that `11ty` was failing because it was incorrectly reading the output path as a param, possibly because 11ty has changed its param handling recently.

```
      - name: Build 11ty
        uses: mcfitzgerald/action-build-eleventy@2.01
        with:
          path: $GITHUB_WORKSPACE/site
```

I was able to get the GitHub Action working again by changing the above path from `$GITHUB_WORKSPACE/site` to `--output=$GITHUB_WORKSPACE/site`. While this workaround is fine, it seems like this proposed code change would restore the original functionality. I wasn't sure how to test this fix locally; would appreciate if someone could take a look and confirm if this is the right fix.